### PR TITLE
move state to static property instead of global

### DIFF
--- a/.changeset/proud-showers-brake.md
+++ b/.changeset/proud-showers-brake.md
@@ -1,0 +1,7 @@
+---
+"slf": minor
+"slf-sentry": patch
+"slf-debug": patch
+---
+
+Move SLF state from being set globally to be a static property on the LoggerFactory. Update the warning about not having a logger factory to be scheduled, and cancelled if a factory is set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,18 +1124,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.19.0"
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
@@ -2843,15 +2831,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -3945,17 +3924,6 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true
-    },
-    "@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "undici-types": "~7.19.0"
-      }
     },
     "@vitest/expect": {
       "version": "4.1.5",
@@ -5071,14 +5039,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
-    },
-    "undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
         "@changesets/cli": "^2.31.0",
+        "rimraf": "^6.1.3",
         "turbo": "^2.9.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish",
-    "clean": "rm -rf .turbo packages/*/lib packages/*/tsconfig.tsbuildinfo",
-    "clean:full": "npm run clean && rm -rf node_modules packages/*/node_modules shared/*/node_modules",
+    "clean": "rimraf .turbo \"packages/*/lib\" \"packages/*/tsconfig.tsbuildinfo\"",
+    "clean:full": "npm run clean && rimraf node_modules \"packages/*/node_modules\" \"shared/*/node_modules\"",
     "test": "turbo run test",
     "lint": "biome lint .",
     "format": "biome format --write .",
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.13",
     "@changesets/cli": "^2.31.0",
+    "rimraf": "^6.1.3",
     "turbo": "^2.9.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:publish": "changeset publish",
+    "clean": "rm -rf .turbo packages/*/lib packages/*/tsconfig.tsbuildinfo",
+    "clean:full": "npm run clean && rm -rf node_modules packages/*/node_modules shared/*/node_modules",
     "test": "turbo run test",
     "lint": "biome lint .",
     "format": "biome format --write .",

--- a/packages/slf-debug/package.json
+++ b/packages/slf-debug/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest",
     "build": "tsc -b tsconfig.json",
     "dev": "tsc -b tsconfig.json --watch",
-    "prepare": "npm test && npm run build"
+    "prepare": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/packages/slf-debug/src/slfDebugDriver.spec.ts
+++ b/packages/slf-debug/src/slfDebugDriver.spec.ts
@@ -1,8 +1,16 @@
+import debug from 'debug';
 import { LoggerFactory } from 'slf';
 import slfDebugDriver from './slfDebugDriver';
 
 describe('AA', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    LoggerFactory.setFactory(null);
+  });
+
   it('a', () => {
+    const debugLogSpy = vi.spyOn(debug, 'log').mockImplementation(() => undefined);
+
     LoggerFactory.setFactory(slfDebugDriver);
     const alog = LoggerFactory.getLogger('AA:a');
     const blog = LoggerFactory.getLogger('AA:b');
@@ -10,5 +18,7 @@ describe('AA', () => {
     alog.error('Hello', { world: true });
     blog.info('Hello', { world: false });
     alog.error('Bye %o', { world: true });
+
+    expect(debugLogSpy).toHaveBeenCalledTimes(4);
   });
 });

--- a/packages/slf-sentry/package.json
+++ b/packages/slf-sentry/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest",
     "build": "tsc -b tsconfig.json",
     "dev": "tsc -b tsconfig.json --watch",
-    "prepare": "npm test && npm run build"
+    "prepare": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/packages/slf-sentry/src/createSlfSentryDriver.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.ts
@@ -35,7 +35,7 @@ export default function createSlfSentryDriver(
       });
       isInitialized = true;
     } catch (err) {
-      console.log('Failed to initialize logging to Sentry with the given url: %s', sentryUrl);
+      console.warn('Failed to initialize logging to Sentry with the given url: %s', sentryUrl);
       console.error(err);
     }
   }

--- a/packages/slf/package.json
+++ b/packages/slf/package.json
@@ -9,7 +9,7 @@
     "test.watch": "vitest",
     "build": "tsc -b tsconfig.json",
     "dev": "tsc -b tsconfig.json --watch",
-    "prepare": "npm test && npm run build"
+    "prepare": "npm run build && npm test"
   },
   "repository": {
     "type": "git",

--- a/packages/slf/src/Logger.spec.ts
+++ b/packages/slf/src/Logger.spec.ts
@@ -2,10 +2,23 @@ import { Event, Level, Logger, LoggerFactory } from '.';
 
 describe('Logger', () => {
   let log: Logger;
+  const resetLoggerFactoryWarningState = () => {
+    const state = (LoggerFactory as any).state;
+    if (state.warningTimeout) {
+      clearTimeout(state.warningTimeout);
+      state.warningTimeout = null;
+    }
+    state.hasWarned = false;
+  };
+
   beforeAll(() => {
     log = Logger.getLogger(__filename);
   });
+
   afterEach(() => {
+    resetLoggerFactoryWarningState();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     LoggerFactory.setFactory(null);
   });
 
@@ -63,6 +76,71 @@ describe('Logger', () => {
       });
     });
   });
+
+  describe('LoggerFactory constructor defaults', () => {
+    it('should set default factory only when factory is not set', () => {
+      const firstEvents: Event[] = [];
+      const firstFactory = (...events: Event[]) => {
+        firstEvents.push(...events);
+      };
+
+      const secondEvents: Event[] = [];
+      const secondFactory = (...events: Event[]) => {
+        secondEvents.push(...events);
+      };
+
+      new LoggerFactory(firstFactory);
+      new LoggerFactory(secondFactory);
+
+      log.info('constructor-default');
+      expect(firstEvents.length).toBe(1);
+      expect(secondEvents.length).toBe(0);
+    });
+
+    it('should replace static factory via setFactory', () => {
+      const firstEvents: Event[] = [];
+      const firstFactory = (...events: Event[]) => {
+        firstEvents.push(...events);
+      };
+
+      const secondEvents: Event[] = [];
+      const secondFactory = (...events: Event[]) => {
+        secondEvents.push(...events);
+      };
+
+      new LoggerFactory(firstFactory);
+      LoggerFactory.setFactory(secondFactory);
+
+      log.info('set-factory-replace');
+      expect(firstEvents.length).toBe(0);
+      expect(secondEvents.length).toBe(1);
+    });
+  });
+
+  describe('LoggerFactory warning behavior', () => {
+    it('should schedule warning when no factory is installed', () => {
+      vi.useFakeTimers();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      Logger.getLogger('schedule-warning');
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      vi.runAllTimers();
+      expect(consoleSpy).toHaveBeenCalledWith('SLF: No LoggerFactory installed');
+    });
+
+    it('should cancel scheduled warning when factory is installed', () => {
+      vi.useFakeTimers();
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      Logger.getLogger('cancel-warning');
+      LoggerFactory.setFactory(() => undefined);
+
+      vi.runAllTimers();
+      expect(consoleSpy).not.toHaveBeenCalledWith('SLF: No LoggerFactory installed');
+    });
+  });
+
   describe('#debug', () => {
     it('should exist', () => {
       if (!('debug' in log)) {

--- a/packages/slf/src/LoggerFactory.ts
+++ b/packages/slf/src/LoggerFactory.ts
@@ -15,14 +15,6 @@ const checkIfLevelBelow = (event: Event, level: Level = Level.Debug): boolean =>
   return level > Level[levelKey];
 }
 
-const provideToFactory = (events: Array<Event>, level: Level = Level.Debug) => {
-  const filteredEvents = events.filter((e) => !checkIfLevelBelow(e, level));
-  // events is empty if all are below set level
-  if (filteredEvents.length > 0) {
-    __slf._factory?.(...filteredEvents);
-  }
-}
-
 export interface Event {
   timeStamp: number;
   params: any[];
@@ -43,63 +35,99 @@ export interface Middleware {
 }
 
 interface Slf {
-  _chain: Middleware[];
-  _queued: Event[][];
-  _factory: Factory | null;
-  _logLevel: Level | null;
+  chain: Middleware[];
+  queued: Event[][];
+  factory: Factory | null;
+  logLevel: Level | null;
   hasWarned: boolean;
+  warningTimeout: ReturnType<typeof setTimeout> | null;
 }
-
-declare global {
-  var __slf: Slf;
-}
-
-const __slf = global.__slf
-  ? global.__slf
-  : (global.__slf = {
-    _chain: [],
-    _queued: [],
-    _factory: null,
-    _logLevel: null,
-    hasWarned: false
-  });
 
 export class LoggerFactory {
+  private static state: Slf = {
+    chain: [],
+    queued: [],
+    factory: null,
+    logLevel: null,
+    hasWarned: false,
+    warningTimeout: null
+  };
+
+  private static scheduleNoFactoryWarning() {
+    if (LoggerFactory.state.hasWarned || LoggerFactory.state.warningTimeout) {
+      return;
+    }
+
+    LoggerFactory.state.warningTimeout = setTimeout(() => {
+      LoggerFactory.state.warningTimeout = null;
+      if (!LoggerFactory.state.factory && !LoggerFactory.state.hasWarned) {
+        LoggerFactory.state.hasWarned = true;
+        console.warn('SLF: No LoggerFactory installed');
+      }
+    }, 0);
+  }
+
+  private static cancelNoFactoryWarning() {
+    if (!LoggerFactory.state.warningTimeout) {
+      return;
+    }
+
+    clearTimeout(LoggerFactory.state.warningTimeout);
+    LoggerFactory.state.warningTimeout = null;
+  }
+
+  private static provideToFactory(events: Event[], level: Level = Level.Debug) {
+    const filteredEvents = events.filter((e) => !checkIfLevelBelow(e, level));
+    // events is empty if all are below set level
+    if (filteredEvents.length > 0) {
+      LoggerFactory.state.factory?.(...filteredEvents);
+    }
+  }
+
+  constructor(factory?: Factory | null, level?: Level) {
+    if (factory && !LoggerFactory.state.factory) {
+      LoggerFactory.setFactory(factory, level);
+    }
+  }
+
   static getLogger(name: string) {
     let sink;
-    if (__slf._factory) {
-      sink = __slf._factory;
-    } else if (!__slf.hasWarned) {
-      __slf.hasWarned = true;
-      console.log('Warning SLF: No LoggerFactory installed');
+    if (LoggerFactory.state.factory) {
+      sink = LoggerFactory.state.factory;
+    } else {
+      LoggerFactory.scheduleNoFactoryWarning();
     }
     if (!sink) {
       sink = (...args: Event[]) => {
-        if (__slf._factory) {
-          provideToFactory(args, LoggerFactory.getLogLevel());
+        if (LoggerFactory.state.factory) {
+          LoggerFactory.provideToFactory(args, LoggerFactory.getLogLevel());
         } else {
-          __slf._queued[__slf._queued.length % 100] = args;
+          LoggerFactory.state.queued[LoggerFactory.state.queued.length % 100] = args;
         }
       };
     }
-    return new Logger(name, sink, __slf._chain, LoggerFactory.getLogLevel());
+    return new Logger(name, sink, LoggerFactory.state.chain, LoggerFactory.getLogLevel());
   }
   static setFactory(factory: Factory | null, level?: Level) {
-    if (__slf._factory && factory) {
-      console.log('Warning SLF: Replacing installed LoggerFactory', __slf._factory, factory);
-    }
-    if (!factory) {
-      __slf._queued.length = 0;
-    }
-    __slf._factory = factory;
-    if (__slf._factory && __slf._queued.length > 0) {
-      console.log('***** dumping Q');
-      __slf._queued.forEach((evt) => provideToFactory(evt, level));
-      __slf._queued.length = 0;
+    if (factory) {
+      LoggerFactory.cancelNoFactoryWarning();
     }
 
-    if (!__slf._logLevel) {
-      __slf._logLevel = LoggerFactory.getLogLevel(level);
+    if (LoggerFactory.state.factory && factory) {
+      console.warn('SLF: Replacing installed LoggerFactory', LoggerFactory.state.factory, factory);
+    }
+    if (!factory) {
+      LoggerFactory.state.queued.length = 0;
+    }
+    LoggerFactory.state.factory = factory;
+    if (LoggerFactory.state.factory && LoggerFactory.state.queued.length > 0) {
+      console.log('SLF: Sinking queue to factory');
+      LoggerFactory.state.queued.forEach((evt) => LoggerFactory.provideToFactory(evt, level));
+      LoggerFactory.state.queued.length = 0;
+    }
+
+    if (!LoggerFactory.state.logLevel) {
+      LoggerFactory.state.logLevel = LoggerFactory.getLogLevel(level);
     }
   }
   /**
@@ -107,7 +135,7 @@ export class LoggerFactory {
    * next should be called next(err, event);
    */
   static use(middleware: Middleware) {
-    __slf._chain.push(middleware);
+    LoggerFactory.state.chain.push(middleware);
   }
 
   private static getLogLevel(level?: Level | undefined): Level {
@@ -120,6 +148,6 @@ export class LoggerFactory {
         envLevel = capitalized;
       }
     }
-    return __slf._logLevel || level || (envLevel && Level[envLevel]) || Level.Debug;
+    return LoggerFactory.state.logLevel || level || (envLevel && Level[envLevel]) || Level.Debug;
   }
 }


### PR DESCRIPTION
Moves SLF’s internal runtime state off a global (global.__slf) and into a LoggerFactory static property, with updated warning behavior when no factory is installed.

## Changes:

* Refactor LoggerFactory to store chain/queue/factory/log-level state on a private static state object (instead of a global).
* Change “no factory installed” warning to be scheduled (and cancelable when a factory is set), and add/adjust tests around constructor defaults + warning behavior.
* Add repo/package maintenance tweaks: new root clean scripts, reorder prepare script steps, and adjust Sentry init failure logging level.