### PR TITLE
create Sentry driver once and re-use

### DIFF
--- a/.changeset/floppy-rules-work.md
+++ b/.changeset/floppy-rules-work.md
@@ -1,0 +1,5 @@
+---
+"slf-sentry": patch
+---
+
+Do not create a new Sentry driver for each log event.

--- a/packages/slf-sentry/src/createSlfSentryDebugDriver.spec.ts
+++ b/packages/slf-sentry/src/createSlfSentryDebugDriver.spec.ts
@@ -1,4 +1,38 @@
+import { Event } from 'slf';
+import slfDebug from 'slf-debug';
+import createSlfSentryDriver from './createSlfSentryDriver';
+import createSlfSentryDebugDriver from './createSlfSentryDebugDriver';
+
+vi.mock('slf-debug', () => ({
+  default: vi.fn()
+}));
+
+vi.mock('./createSlfSentryDriver', () => ({
+  default: vi.fn()
+}));
+
 describe('#createSlfSentryDebugDriver', () => {
-  it.todo('should pass the event to the SLF Debug Driver');
-  it.todo('should pass the event to the SLF Sentry Driver');
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create the Sentry driver only once and reuse it for each event', () => {
+    const slfSentry = vi.fn();
+    vi.mocked(createSlfSentryDriver).mockReturnValue(slfSentry);
+
+    const driver = createSlfSentryDebugDriver('https://sentry.example.com');
+    const event = {} as Event;
+
+    driver(event);
+    driver(event);
+
+    expect(createSlfSentryDriver).toHaveBeenCalledTimes(1);
+    expect(createSlfSentryDriver).toHaveBeenCalledWith('https://sentry.example.com', undefined);
+    expect(slfDebug).toHaveBeenCalledTimes(2);
+    expect(slfDebug).toHaveBeenNthCalledWith(1, event);
+    expect(slfDebug).toHaveBeenNthCalledWith(2, event);
+    expect(slfSentry).toHaveBeenCalledTimes(2);
+    expect(slfSentry).toHaveBeenNthCalledWith(1, event);
+    expect(slfSentry).toHaveBeenNthCalledWith(2, event);
+  });
 });

--- a/packages/slf-sentry/src/createSlfSentryDebugDriver.ts
+++ b/packages/slf-sentry/src/createSlfSentryDebugDriver.ts
@@ -2,10 +2,13 @@ import { Event } from 'slf';
 import slfDebug from 'slf-debug';
 import createSlfSentryDriver, { CreateSlfSentryLoggerOptions } from './createSlfSentryDriver';
 
-const createSlfSentryDebugDriver = (sentryUrl: string, options?: CreateSlfSentryLoggerOptions) => (event: Event) => {
-  slfDebug(event);
+const createSlfSentryDebugDriver = (sentryUrl: string, options?: CreateSlfSentryLoggerOptions) => {
   const slfSentry = createSlfSentryDriver(sentryUrl, options);
-  slfSentry(event);
+
+  return (event: Event) => {
+    slfDebug(event);
+    slfSentry(event);
+  };
 };
 
 export default createSlfSentryDebugDriver;


### PR DESCRIPTION
This PR updates the `slf-sentry` debug driver factory to create the Sentry driver once per factory invocation and reuse it for all subsequent log events, avoiding repeated driver creation during logging.

Addresses https://github.com/surikaterna/slf/issues/23

## Changes
- Refactor `createSlfSentryDebugDriver` to instantiate the Sentry driver once and return a closure that reuses it per event.
- Add a Vitest spec asserting the Sentry driver factory is called only once while both debug and sentry handlers run for each event.
- Add a changeset to release the optimization as a patch.