### PR TITLE
skip logging for invalid log levels in Sentry driver

### DIFF
--- a/.changeset/smart-trains-rush.md
+++ b/.changeset/smart-trains-rush.md
@@ -1,0 +1,5 @@
+---
+"slf-sentry": patch
+---
+
+Verify valid log level.

--- a/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
@@ -1,7 +1,77 @@
+import { captureException, captureMessage, setTag, withScope } from '@sentry/node';
+import { Event } from 'slf';
+import createSlfSentryDriver from './createSlfSentryDriver';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  init: vi.fn(),
+  setTag: vi.fn(),
+  withScope: vi.fn((cb: (scope: { setExtra: (k: string, v: unknown) => void; setLevel: (level: string) => void }) => void) => {
+    cb({
+      setExtra: vi.fn(),
+      setLevel: vi.fn()
+    });
+  })
+}));
+
 describe('#createSlfSentryDriver', () => {
-  it.todo('should send exception to Sentry if there is an error in the parameters');
-  it.todo('should send message to Sentry if there are no errors in the parameters');
-  it.todo('should provide context parameters to Sentry if provided in the event');
-  it.todo('should not send to Sentry if the log level is below specified error level');
-  it.todo('should not send to Sentry if the log level is not found in error levels');
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should warn and send nothing if configured level is invalid', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const driver = createSlfSentryDriver('https://sentry.example.com', {
+      level: 'invalid-level',
+      levels: ['error', 'warn']
+    });
+
+    driver({
+      level: 'error',
+      name: 'test-event',
+      params: ['test message']
+    } as Event);
+
+    expect(warnSpy).toHaveBeenCalledWith('SLF: Invalid Sentry log level "%s". Allowed levels: %s. Sentry logging is disabled.', 'invalid-level', 'error, warn');
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('should not send to Sentry if the event log level is not found in levels', () => {
+    const driver = createSlfSentryDriver('https://sentry.example.com', {
+      level: 'warn',
+      levels: ['error', 'warn']
+    });
+
+    driver({
+      level: 'info',
+      name: 'test-event',
+      params: ['test message']
+    } as Event);
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('should send message when event level is same or above configured level', () => {
+    const driver = createSlfSentryDriver('https://sentry.example.com', {
+      level: 'warn',
+      levels: ['error', 'warn', 'info']
+    });
+
+    driver({
+      level: 'warn',
+      name: 'test-event',
+      params: ['test message']
+    } as Event);
+
+    expect(setTag).not.toHaveBeenCalled();
+    expect(withScope).toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith('test message');
+    expect(captureException).not.toHaveBeenCalled();
+  });
 });

--- a/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
@@ -25,7 +25,7 @@ describe('#createSlfSentryDriver', () => {
 
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'invalid-level',
-      levels: ['error', 'warn']
+      levels: ['info', 'warn', 'error']
     });
 
     driver({
@@ -34,7 +34,7 @@ describe('#createSlfSentryDriver', () => {
       params: ['test message']
     } as Event);
 
-    expect(warnSpy).toHaveBeenCalledWith('SLF: Invalid Sentry log level "%s". Allowed levels: %s. Sentry logging is disabled.', 'invalid-level', 'error, warn');
+    expect(warnSpy).toHaveBeenCalledWith('SLF: Invalid Sentry log level "%s". Allowed levels: %s. Sentry logging is disabled.', 'invalid-level', 'info, warn, error');
     expect(captureException).not.toHaveBeenCalled();
     expect(captureMessage).not.toHaveBeenCalled();
 
@@ -44,11 +44,11 @@ describe('#createSlfSentryDriver', () => {
   it('should not send to Sentry if the event log level is not found in levels', () => {
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
-      levels: ['error', 'warn']
+      levels: ['info', 'warn', 'error']
     });
 
     driver({
-      level: 'info',
+      level: 'debug',
       name: 'test-event',
       params: ['test message']
     } as Event);
@@ -60,7 +60,7 @@ describe('#createSlfSentryDriver', () => {
   it('should send message when event level is same or above configured level', () => {
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
-      levels: ['error', 'warn', 'info']
+      levels: ['info', 'warn', 'error']
     });
 
     driver({

--- a/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
@@ -74,4 +74,38 @@ describe('#createSlfSentryDriver', () => {
     expect(captureMessage).toHaveBeenCalledWith('test message');
     expect(captureException).not.toHaveBeenCalled();
   });
+
+  it('should send when event level is above configured level', () => {
+    const driver = createSlfSentryDriver('https://sentry.example.com', {
+      level: 'warn',
+      levels: ['info', 'warn', 'error']
+    });
+
+    driver({
+      level: 'error',
+      name: 'test-event',
+      params: ['test message']
+    } as Event);
+
+    expect(withScope).toHaveBeenCalled();
+    expect(captureMessage).toHaveBeenCalledWith('test message');
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('should not send when event level is below configured level', () => {
+    const driver = createSlfSentryDriver('https://sentry.example.com', {
+      level: 'warn',
+      levels: ['info', 'warn', 'error']
+    });
+
+    driver({
+      level: 'info',
+      name: 'test-event',
+      params: ['test message']
+    } as Event);
+
+    expect(withScope).not.toHaveBeenCalled();
+    expect(captureMessage).not.toHaveBeenCalled();
+    expect(captureException).not.toHaveBeenCalled();
+  });
 });

--- a/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.spec.ts
@@ -1,8 +1,6 @@
-import { captureException, captureMessage, setTag, withScope } from '@sentry/node';
 import { Event } from 'slf';
-import createSlfSentryDriver from './createSlfSentryDriver';
 
-vi.mock('@sentry/node', () => ({
+const sentryMocks = vi.hoisted(() => ({
   captureException: vi.fn(),
   captureMessage: vi.fn(),
   init: vi.fn(),
@@ -15,12 +13,28 @@ vi.mock('@sentry/node', () => ({
   })
 }));
 
+vi.mock('@sentry/node', () => ({
+  captureException: sentryMocks.captureException,
+  captureMessage: sentryMocks.captureMessage,
+  init: sentryMocks.init,
+  setTag: sentryMocks.setTag,
+  withScope: sentryMocks.withScope
+}));
+
+async function loadCreateSlfSentryDriver() {
+  const module = await import('./createSlfSentryDriver');
+
+  return module.default;
+}
+
 describe('#createSlfSentryDriver', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
   });
 
-  it('should warn and send nothing if configured level is invalid', () => {
+  it('should warn and send nothing if configured level is invalid', async () => {
+    const createSlfSentryDriver = await loadCreateSlfSentryDriver();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
     const driver = createSlfSentryDriver('https://sentry.example.com', {
@@ -35,13 +49,14 @@ describe('#createSlfSentryDriver', () => {
     } as Event);
 
     expect(warnSpy).toHaveBeenCalledWith('SLF: Invalid Sentry log level "%s". Allowed levels: %s. Sentry logging is disabled.', 'invalid-level', 'info, warn, error');
-    expect(captureException).not.toHaveBeenCalled();
-    expect(captureMessage).not.toHaveBeenCalled();
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
 
     warnSpy.mockRestore();
   });
 
-  it('should not send to Sentry if the event log level is not found in levels', () => {
+  it('should not send to Sentry if the event log level is not found in levels', async () => {
+    const createSlfSentryDriver = await loadCreateSlfSentryDriver();
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
       levels: ['info', 'warn', 'error']
@@ -53,11 +68,12 @@ describe('#createSlfSentryDriver', () => {
       params: ['test message']
     } as Event);
 
-    expect(captureException).not.toHaveBeenCalled();
-    expect(captureMessage).not.toHaveBeenCalled();
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
   });
 
-  it('should send message when event level is same or above configured level', () => {
+  it('should send message when event level is same or above configured level', async () => {
+    const createSlfSentryDriver = await loadCreateSlfSentryDriver();
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
       levels: ['info', 'warn', 'error']
@@ -69,13 +85,14 @@ describe('#createSlfSentryDriver', () => {
       params: ['test message']
     } as Event);
 
-    expect(setTag).not.toHaveBeenCalled();
-    expect(withScope).toHaveBeenCalled();
-    expect(captureMessage).toHaveBeenCalledWith('test message');
-    expect(captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.setTag).not.toHaveBeenCalled();
+    expect(sentryMocks.withScope).toHaveBeenCalled();
+    expect(sentryMocks.captureMessage).toHaveBeenCalledWith('test message');
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
 
-  it('should send when event level is above configured level', () => {
+  it('should send when event level is above configured level', async () => {
+    const createSlfSentryDriver = await loadCreateSlfSentryDriver();
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
       levels: ['info', 'warn', 'error']
@@ -87,12 +104,13 @@ describe('#createSlfSentryDriver', () => {
       params: ['test message']
     } as Event);
 
-    expect(withScope).toHaveBeenCalled();
-    expect(captureMessage).toHaveBeenCalledWith('test message');
-    expect(captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.withScope).toHaveBeenCalled();
+    expect(sentryMocks.captureMessage).toHaveBeenCalledWith('test message');
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
 
-  it('should not send when event level is below configured level', () => {
+  it('should not send when event level is below configured level', async () => {
+    const createSlfSentryDriver = await loadCreateSlfSentryDriver();
     const driver = createSlfSentryDriver('https://sentry.example.com', {
       level: 'warn',
       levels: ['info', 'warn', 'error']
@@ -104,8 +122,8 @@ describe('#createSlfSentryDriver', () => {
       params: ['test message']
     } as Event);
 
-    expect(withScope).not.toHaveBeenCalled();
-    expect(captureMessage).not.toHaveBeenCalled();
-    expect(captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.withScope).not.toHaveBeenCalled();
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
 });

--- a/packages/slf-sentry/src/createSlfSentryDriver.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.ts
@@ -18,7 +18,7 @@ export interface CreateSlfSentryLoggerOptions {
    */
   environment?: string;
   /**
-   * Ordered log levels from highest to lowest priority. Used to compare event levels against `level`.
+   * Ordered log levels from lowest to highest priority. Used to compare event levels against `level`.
    * Defaults to only `error`.
    */
   levels?: Array<string>;

--- a/packages/slf-sentry/src/createSlfSentryDriver.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.ts
@@ -18,6 +18,11 @@ export default function createSlfSentryDriver(
   { debug, environment = process.env.SENTRY_ENV ?? 'dev', level = 'error', levels = ['error'], release, shouldIgnore, tags }: CreateSlfSentryLoggerOptions = {}
 ) {
   const levelIndex = levels.indexOf(level);
+  const isInvalidLevel = levelIndex === -1;
+
+  if (isInvalidLevel) {
+    console.warn('SLF: Invalid Sentry log level "%s". Allowed levels: %s. Sentry logging is disabled.', level, levels.join(', '));
+  }
 
   if (!isInitialized) {
     try {
@@ -45,7 +50,16 @@ export default function createSlfSentryDriver(
   }
 
   function checkIsEventLevelSameOrAbove(eventLogLevel: string): boolean {
+    if (isInvalidLevel) {
+      return false;
+    }
+
     const eventLevelIndex = levels.indexOf(eventLogLevel);
+
+    if (eventLevelIndex === -1) {
+      return false;
+    }
+
     return levelIndex <= eventLevelIndex;
   }
 

--- a/packages/slf-sentry/src/createSlfSentryDriver.ts
+++ b/packages/slf-sentry/src/createSlfSentryDriver.ts
@@ -2,17 +2,42 @@ import { captureException, captureMessage, init, setTag, SeverityLevel, withScop
 import { Event } from 'slf';
 
 export interface CreateSlfSentryLoggerOptions {
+  /**
+   * Enables Sentry SDK debug mode.
+   * By default, debug mode is enabled in `fat` and `dev` environments.
+   */
   debug?: boolean;
+  /**
+   * Minimum log level that will be sent to Sentry. The value must exist in `levels`.
+   * Defaults to `error`.
+   */
   level?: string;
+  /**
+   * Sentry environment name.
+   * Defaults to the `SENTRY_ENV` environment variable, or `dev` if it is not set.
+   */
   environment?: string;
+  /**
+   * Ordered log levels from highest to lowest priority. Used to compare event levels against `level`.
+   * Defaults to only `error`.
+   */
   levels?: Array<string>;
+  /** Release identifier attached to reported Sentry events. */
   release?: string;
+  /** Optional predicate to skip sending matching events. */
   shouldIgnore?: (event: Event) => boolean;
+  /** Tags added to Sentry events for filtering and grouping. */
   tags?: Record<string, string | number | boolean>;
 }
 
 let isInitialized = false;
 
+/**
+ * Creates an SLF driver that forwards matching events to Sentry.
+ *
+ * If `level` is not included in `levels`, the driver logs a warning and
+ * drops all events instead of sending anything to Sentry.
+ */
 export default function createSlfSentryDriver(
   sentryUrl: string,
   { debug, environment = process.env.SENTRY_ENV ?? 'dev', level = 'error', levels = ['error'], release, shouldIgnore, tags }: CreateSlfSentryLoggerOptions = {}


### PR DESCRIPTION
This PR updates the `slf-sentry` driver to avoid forwarding events to Sentry when the configured minimum log level is invalid, and adds unit tests plus a changeset entry to release the fix.

## Changes
- Add validation for `options.level` vs `options.levels`, warn on invalid configuration, and drop events.
- Harden level filtering by skipping events whose `event.level` is not present in `levels`.
- Replace TODOs with real tests and add a patch changeset for `slf-sentry`.